### PR TITLE
Update video URL and readme links

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
 <body>
 <div class="container">
 <div class="vidwrap">
-<iframe width="1280" height="720" src="http://www.youtube.com/embed/g3wy1Nh8-KA" frameborder="0" allowfullscreen></iframe>
+<iframe width="1280" height="720" src="https://www.youtube.com/embed/g3wy1Nh8-KA" frameborder="0" allowfullscreen></iframe>
 </div>
 <div class="imgwrap">
 <a target="_blank" href="pinkpony1.jpg"><img class="limg" src="pinkpony1.jpg"></a>
@@ -26,11 +26,11 @@
 <p>
 <h1>Pink Pony</h1> is a colorful tron-like 3D racing game with ponies and computer-controlled opponents, as well as multiplayer split-screen support for up to four people via keyboard or game controller.</p>
 
-<p>Pink Pony can be played both on <strong>Linux</strong> and <strong>Windows</strong> and is both <strong>free</strong> and <strong>open source</strong> (see <a href="https://github.com/ginkgo/pink-pony/blob/master/README">readme text</a>).</p>
+<p>Pink Pony can be played both on <strong>Linux</strong> and <strong>Windows</strong> and is both <strong>free</strong> and <strong>open source</strong> (see <a href="https://github.com/ginkgo/pink-pony">readme text</a>).</p>
 
 <div class="dlwrap">
-<a class="dl" href="https://code.google.com/p/pink-pony/downloads/list?can=1"><div><span class="dltop">Download Pink Pony</span><br>
-<span class="dlsub">from Google Code</span></div></a>
+<a class="dl" href="https://github.com/ginkgo/pink-pony/releases"><div><span class="dltop">Download Pink Pony</span><br>
+<span class="dlsub">from GitHub</span></div></a>
 </div>
 
 <h2>How to Play</h2>
@@ -61,7 +61,7 @@
 
 <p>Pink Pony is hosted at <a href="https://github.com/ginkgo/pink-pony">github.com/ginkgo/pink-pony</a>.</p>
 
-<p>For more information, including compile instructions, credits and license information, please see the <a href="https://github.com/ginkgo/pink-pony/blob/master/README">readme file</a>.</p>
+<p>For more information, including compile instructions, credits and license information, please see the <a href="https://github.com/ginkgo/pink-pony">readme file</a>.</p>
 </div>
 </body>
 </html>


### PR DESCRIPTION
1. The YouTube embed was blocked in most browsers for using http rather than https. This is fixed.
2. The Google Code download link is updated to GitHub releases. Ideally there will be a sort of selector for different distros that takes you to repo or launches the relevant application, but I didn't implement that yet.
3. References to the readme link to the main github page now since I just changed README to README.md in the other PR